### PR TITLE
[DF-529] Implement Group Pull endpoints

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -86,7 +86,7 @@ func (c *AuthentikClient) PaginatedListUsers(ctx *gin.Context) (users []authenti
 	ctxWithAuth := c.addAuthTokenToCtx(ctx)
 	paginatedUsers, resp, err := c.client.CoreApi.CoreUsersList(ctxWithAuth).Page(page).PageSize(DefaultPageSize).Execute()
 	if err != nil {
-		return nil, "", &ClientError{StatusCode: resp.StatusCode, Message: "Failed to list users from Authentik!", innerError: err}
+		return nil, "", &ClientError{StatusCode: resp.StatusCode, Message: "failed to list users from Authentik", innerError: err}
 	}
 
 	return paginatedUsers.Results, getNextCursorFromPagination(paginatedUsers.Pagination), nil
@@ -101,7 +101,7 @@ func (c *AuthentikClient) PaginatedListGroups(ctx *gin.Context) (groups []authen
 	ctxWithAuth := c.addAuthTokenToCtx(ctx)
 	paginatedGroups, resp, err := c.client.CoreApi.CoreGroupsList(ctxWithAuth).Page(page).PageSize(DefaultPageSize).Execute()
 	if err != nil {
-		return nil, "", &ClientError{StatusCode: resp.StatusCode, Message: "Failed to list groups from Authentik!", innerError: err}
+		return nil, "", &ClientError{StatusCode: resp.StatusCode, Message: "failed to list groups from Authentik", innerError: err}
 	}
 
 	return paginatedGroups.Results, getNextCursorFromPagination(paginatedGroups.Pagination), nil
@@ -111,10 +111,7 @@ func (c *AuthentikClient) GetGroupUsers(ctx *gin.Context, groupID string) (membe
 	ctxWithAuth := c.addAuthTokenToCtx(ctx)
 	group, resp, err := c.client.CoreApi.CoreGroupsRetrieve(ctxWithAuth, groupID).IncludeUsers(true).Execute()
 	if err != nil {
-		if resp.StatusCode == 404 {
-			return nil, nil
-		}
-		return nil, &ClientError{StatusCode: resp.StatusCode, Message: "Failed to get users for group!", innerError: err}
+		return nil, &ClientError{StatusCode: resp.StatusCode, Message: "failed to get users for group from Authentik", innerError: err}
 	}
 
 	return group.UsersObj, nil
@@ -124,10 +121,7 @@ func (c *AuthentikClient) GetGroup(ctx *gin.Context, groupID string) (group *aut
 	ctxWithAuth := c.addAuthTokenToCtx(ctx)
 	group, resp, err := c.client.CoreApi.CoreGroupsRetrieve(ctxWithAuth, groupID).IncludeUsers(false).Execute()
 	if err != nil {
-		if resp.StatusCode == 404 {
-			return nil, nil
-		}
-		return nil, &ClientError{StatusCode: resp.StatusCode, Message: "Failed to get group!", innerError: err}
+		return nil, &ClientError{StatusCode: resp.StatusCode, Message: "failed to get group from authentik", innerError: err}
 	}
 
 	return group, nil


### PR DESCRIPTION
[DF-529: Implement Group "puller" endpoints](https://linear.app/opalsecurity/issue/DF-529/implement-group-puller-endpoints)

Adds the following endpoints
- `GetGroup`
- `GetGroups`
- `GetGroupUsers`

## Manual tests

GetGroups endpoint
```
curl http://localhost:8080/groups | jq .
```
```
{
  "next_cursor": "",
  "groups": [
    {
      "id": "2af1e0b1-7d5d-4be5-98bc-23b3e042a220",
      "name": "OpalServiceAccount"
    },
    {
      "id": "ed0c9e06-26c9-48e5-b4e6-f59d830803c1",
      "name": "authentik Admins"
    },
    {
      "id": "77fde861-7acc-4cd8-800c-1bae112e021e",
      "name": "authentik Read-only"
    }
  ]
}
```

GetGroup endpoint
```
curl http://localhost:8080/groups/ed0c9e06-26c9-48e5-b4e6-f59d830803c1 | jq .
```
```
{
  "group": {
    "id": "ed0c9e06-26c9-48e5-b4e6-f59d830803c1",
    "name": "authentik Admins"
  }
}
```

GetGroupUsers endpoint
```
curl http://localhost:8080/groups/ed0c9e06-26c9-48e5-b4e6-f59d830803c1/users | jq .
```
```
{
  "next_cursor": "",
  "users": [
    {
      "user_id": "6",
      "email": "shrinjay@opal.dev"
    }
  ]
}
```